### PR TITLE
Fix the BAD_CLIENT_ID error

### DIFF
--- a/lib/omniauth/strategies/hubspot.rb
+++ b/lib/omniauth/strategies/hubspot.rb
@@ -10,7 +10,8 @@ module OmniAuth
       option :client_options, {
         site: 'https://api.hubapi.com',
         authorize_url: 'https://app.hubspot.com/oauth/authorize',
-        token_url: 'oauth/v1/token'
+        token_url: 'oauth/v1/token',
+        auth_scheme: :request_body
       }
     end
   end


### PR DESCRIPTION

The oauth2 gem has [changed](https://github.com/oauth-xx/oauth2/pull/312) a bit, so we get this

    OAuth2::Error ({"status":"BAD_CLIENT_ID","message":"missing or unknown client id","correlationId":"81dc7b98-ad56-4e13-8f8e-4a0bb7446117"}):

This attempts to fix that.